### PR TITLE
types: re-export interfaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export { getCharacters, getCharacter } from './character'
 export { getLocations, getLocation } from './location'
 export { getEpisodes, getEpisode } from './episode'
 export { getEndpoints } from './endpoints'
+export * from './interfaces';


### PR DESCRIPTION
The interfaces declared in `interface.ts` are unavailable to the library user. This PR re-exports them from `index.ts` to fix this issue.