### PR TITLE
fix: remove double-slash in generated request URLs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,4 @@ export { getCharacters, getCharacter } from './character'
 export { getLocations, getLocation } from './location'
 export { getEpisodes, getEpisode } from './episode'
 export { getEndpoints } from './endpoints'
-export * from './interfaces';
+export * from './interfaces'

--- a/src/utils/getResource.ts
+++ b/src/utils/getResource.ts
@@ -12,7 +12,7 @@ export interface GetResource {
 const getResource = async ({ endpoint, options, isIdRequired = false }: GetResource): Promise<any> => {
   const qs = generateQueryString(options, isIdRequired)
 
-  return get(`${endpoint}/${qs}`)
+  return get(`${endpoint}${qs}`)
 }
 
 export default getResource

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -2,6 +2,8 @@
 //@ts-nocheck
 import { getCharacter, getCharacters } from '../character'
 import generateQueryString, { errorMessage, isArrayOfIntegers } from './generateQueryString'
+import getResource from './getResource'
+import * as get from './get'
 
 describe('generateQueryString', () => {
   test('Id or Ids', () => {
@@ -32,6 +34,18 @@ describe('isArrayOfIntegers', () => {
   test('false', () => {
     expect(isArrayOfIntegers([1, 'b'])).toBe(false)
     expect(isArrayOfIntegers([1, 1.2])).toBe(false)
+  })
+})
+
+describe('getResource', () => {
+  test('combines endpoint and query string into a single request URL', async () => {
+    const getSpy = jest.spyOn(get, 'default').mockResolvedValue({ data: {}, status: 200, statusMessage: 'OK' })
+
+    await getResource({ endpoint: 'character', options: 1, isIdRequired: true })
+
+    expect(getSpy).toHaveBeenCalledWith('character/1')
+
+    getSpy.mockRestore()
   })
 })
 


### PR DESCRIPTION
- Fixed double-slash in URL, produced by `getResource()` function.

`getResource()` joins `${endpoint}/${qs}` where `generateQueryString()` already returns a leading '/' (e.g. `/1`, `/?name=rick`), producing URL's like `character//1`, which results in 404 response from the server. Since the tests are hitting real server, some of them were failing as well (due to double-slash in URL).

Simplest solution here is to remove '/' when joining `${endpoint}${qs}`, which fixes 404 server error and all pre-existing tests are passing now. Additionally, one more test was added to check return value of `getResource()` (or to be specific with what attributes it calls `get()` function).


- Probable root cause

In this case two things have to be separated: "what has to be fixed?" and "what changes made an error to appear?"

First part is already addressed above, but an interesting part is that double-slash was present in the API Client since the beginning yet it was not causing any issues. The quick answer is that the server was using and older version of Express.

At some point the server was redeployed with a newer version of Express (4.20.x+) which comes with a newer version of it's own dependence `path-to-regexp`, which got stricter rules for matching path segments. And at that point server stopped silently absorbing loosely matched URL's, which likely happend after 2024-09-10, when Express bumped the version of `path-to-regexp`.